### PR TITLE
Fix examples

### DIFF
--- a/examples/cmake-fetchcontent-from-source/project/CMakeLists.txt
+++ b/examples/cmake-fetchcontent-from-source/project/CMakeLists.txt
@@ -12,8 +12,8 @@ project(dqcsim-cmake-example
 # using the C interface, you'll need to set this.
 set(CMAKE_CXX_STANDARD 11)
 
-if (DEFINED ENV{GITHUB_SHA})
-  set(DQCSIM_TAG $ENV{GITHUB_SHA})
+if (DEFINED ENV{GITHUB_HEAD_REF})
+  set(DQCSIM_TAG $ENV{GITHUB_HEAD_REF})
 else()
   set(DQCSIM_TAG "master")
 endif()

--- a/examples/cmake-fetchcontent-from-source/project/CMakeLists.txt
+++ b/examples/cmake-fetchcontent-from-source/project/CMakeLists.txt
@@ -12,12 +12,18 @@ project(dqcsim-cmake-example
 # using the C interface, you'll need to set this.
 set(CMAKE_CXX_STANDARD 11)
 
+if (DEFINED ENV{GITHUB_SHA})
+  set(DQCSIM_TAG $ENV{GITHUB_SHA})
+else()
+  set(DQCSIM_TAG "master")
+endif()
+
 # You can use the FetchContent module (added in CMake 3.14!) with DQCsim like
 # this:
 include(FetchContent)
 FetchContent_Declare(dqcsim
   GIT_REPOSITORY  https://github.com/qe-lab/dqcsim.git
-  GIT_TAG         master
+  GIT_TAG         ${DQCSIM_TAG}
 )
 set(DQCSIM_FROM_SOURCE "yes")
 FetchContent_MakeAvailable(dqcsim)

--- a/examples/cmake-fetchcontent/Makefile
+++ b/examples/cmake-fetchcontent/Makefile
@@ -6,7 +6,7 @@ all: run clean
 
 .PHONY: run
 run: build/main
-	build/main
+	cd build && ./main
 
 build/main:
 	mkdir -p build

--- a/examples/cmake-fetchcontent/project/CMakeLists.txt
+++ b/examples/cmake-fetchcontent/project/CMakeLists.txt
@@ -12,8 +12,8 @@ project(dqcsim-cmake-example
 # using the C interface, you'll need to set this.
 set(CMAKE_CXX_STANDARD 11)
 
-if (DEFINED ENV{GITHUB_SHA})
-  set(DQCSIM_TAG $ENV{GITHUB_SHA})
+if (DEFINED ENV{GITHUB_HEAD_REF})
+  set(DQCSIM_TAG $ENV{GITHUB_HEAD_REF})
 else()
   set(DQCSIM_TAG "master")
 endif()

--- a/examples/cmake-fetchcontent/project/CMakeLists.txt
+++ b/examples/cmake-fetchcontent/project/CMakeLists.txt
@@ -12,12 +12,18 @@ project(dqcsim-cmake-example
 # using the C interface, you'll need to set this.
 set(CMAKE_CXX_STANDARD 11)
 
+if (DEFINED ENV{GITHUB_SHA})
+  set(DQCSIM_TAG $ENV{GITHUB_SHA})
+else()
+  set(DQCSIM_TAG "master")
+endif()
+
 # You can use the FetchContent module (added in CMake 3.14!) with DQCsim like
 # this:
 include(FetchContent)
 FetchContent_Declare(dqcsim
   GIT_REPOSITORY  https://github.com/qe-lab/dqcsim.git
-  GIT_TAG         master
+  GIT_TAG         ${DQCSIM_TAG}
 )
 FetchContent_MakeAvailable(dqcsim)
 


### PR DESCRIPTION
Make sure to build cmake-fetchcontent examples against sha of current workflow and fix Makefile for linux builds.